### PR TITLE
fix(types): allow async function for `additionalPages`

### DIFF
--- a/packages/vuepress-types/types/plugin.d.ts
+++ b/packages/vuepress-types/types/plugin.d.ts
@@ -58,7 +58,9 @@ export interface PluginOptionAPI {
   >
   extendPageData?: (page: Page) => void | Promise<void>
   clientRootMixin?: string
-  additionalPages?: Partial<PageOptions>[] | Promise<Partial<PageOptions>[]>
+  additionalPages?:
+    | Partial<PageOptions>[]
+    | (() => Promise<Partial<PageOptions>[]>)
   globalUIComponents?: string | string[]
   extendCli?: (cli: CAC) => void
   multiple?: boolean


### PR DESCRIPTION
**Summary**

**Which package does this PR involve?** (check one)

- [x] vuepress-types

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fix)

**Does this PR introduce a breaking change?** (check one)

- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
According to [the docs](https://vuepress.vuejs.org/plugin/option-api.html#additionalpages), the correct type for the `additionalPages` property of a plugin's options is `Array | AsyncFunction`.

Currently, code like this:
```ts
const GhostPlugin: Plugin<MyPluginOptions> = (options, context) => ({
  async additionalPages(): Promise<Partial<PageOptions>[]> {
    const pages: Partial<PageOptions>[] = getMyPages()
    return pages
  }
})
```
produces this error when compiling the plugin.
```
Type '() => Promise<Partial<PageOptions>[]>' is not assignable to type 'Partial<PageOptions>[] | Promise<Partial<PageOptions>[]> | undefined'
```
Passing a `Promise` instead of an async function produces
```
warning: Invalid value for "option" additionalPages: expected a Function or Array but got Promise.
```
when using the plugin with VuePress.

This PR enables passing an async function for `additionalPages`.