### PR TITLE
fix: dependency issues in typescript and container plugin

### DIFF
--- a/packages/vuepress-plugin-container/package.json
+++ b/packages/vuepress-plugin-container/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint --ext .ts src test"
   },
   "dependencies": {
-    "markdown-it-container": "^2.0.0"
+    "markdown-it-container": "^2.0.0",
+    "@vuepress/shared-utils": "^1.2.0"
   }
 }

--- a/packages/vuepress-plugin-typescript/package.json
+++ b/packages/vuepress-plugin-typescript/package.json
@@ -27,10 +27,14 @@
     "lint": "eslint --ext .ts,.vue src test"
   },
   "dependencies": {
+    "cache-loader": "^3.0.0",
     "ts-loader": "^7.0.3"
   },
   "devDependencies": {
     "vue-class-component": "^7.1.0",
     "vue-property-decorator": "^8.3.0"
+  },
+  "peerDependencies": {
+    "typescript": "*"
   }
 }

--- a/packages/vuepress-plugin-typescript/src/index.ts
+++ b/packages/vuepress-plugin-typescript/src/index.ts
@@ -47,14 +47,14 @@ const TypescriptPlugin: Plugin<TypescriptPluginOptions> = (
       .rule('ts')
       .test(/\.ts$/)
       .use('cache-loader')
-      .loader('cache-loader')
+      .loader(require.resolve('cache-loader'))
       .options({
         cacheDirectory,
         cacheIdentifier: finalCacheIdentifier,
       })
       .end()
       .use('ts-loader')
-      .loader('ts-loader')
+      .loader(require.resolve('ts-loader'))
       .options({
         appendTsSuffixTo: [/\.vue$/, /\.md$/],
         compilerOptions: {


### PR DESCRIPTION
**Summary**

Working on making vuepress work with Yarn PnP, though these fixes aren't PnP specific.

- Fixes `vuepress-plugin-typescript` adding webpack loaders using their name instead of absolute location, read here for why that is a problem https://github.com/yarnpkg/berry/blob/ead77bd4612267035f1741a76b18e3b00e9069c7/packages/yarnpkg-doctor/README.md#no-unqualified-webpack-config
- Adds missing dependency `cache-loader` to `vuepress-plugin-typescript`
- Adds missing peer dependency `typescript` to `vuepress-plugin-typescript` which is inherited from `ts-loader`
- Adds missing dependency `@vuepress/shared-utils` to `vuepress-plugin-container`

**Which package does this PR involve?** (check one)

- [ ] root project
- [ ] vuepress-plugin-clean-urls
- [x] vuepress-plugin-container
- [ ] vuepress-plugin-dehydrate
- [ ] vuepress-plugin-medium-zoom
- [ ] vuepress-plugin-named-chunks
- [ ] vuepress-plugin-nprogress
- [ ] vuepress-plugin-redirect
- [ ] vuepress-plugin-smooth-scroll
- [ ] vuepress-plugin-table-of-contents
- [x] vuepress-plugin-typescript
- [ ] vuepress-plugin-zooming
- [ ] vuepress-mergeable
- [ ] vuepress-types

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fix)
- [ ] Feature (feat)
- [ ] Performance enhancement (perf)
- [ ] Code Style (style)
- [ ] Refactor (refactor)
- [ ] Docs (docs)
- [ ] Build-related changes (build)
- [ ] CI-related changes (ci)
- [ ] Testing (test)
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)