### PR TITLE
fix(plugin-dehydrate): find string in a right way

### DIFF
--- a/packages/vuepress-plugin-dehydrate/src/index.ts
+++ b/packages/vuepress-plugin-dehydrate/src/index.ts
@@ -75,13 +75,13 @@ const DehydratePlugin: Plugin<DehydratePluginOptions> = (
   ready(): void {
     // hack into current ssr template
     let template = readFileSync(context.ssrTemplate, 'utf8')
-    if (template.search(contentWrapper) < 0) {
+    if (template.indexOf(contentWrapper) < 0) {
       template = template.replace(contentOriginal, contentWrapper)
     }
-    if (template.search(resourceWrapper) < 0) {
+    if (template.indexOf(resourceWrapper) < 0) {
       template = template.replace(resourceOriginal, resourceWrapper)
     }
-    if (template.search(scriptsWrapper) < 0) {
+    if (template.indexOf(scriptsWrapper) < 0) {
       template = template.replace(scriptsOriginal, scriptsWrapper)
     }
     writeFileSync(context.ssrTemplate, template)


### PR DESCRIPTION


<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**Which package does this PR involve?** (check one)

- [ ] root project
- [ ] vuepress-plugin-clean-urls
- [ ] vuepress-plugin-container
- [x] vuepress-plugin-dehydrate
- [ ] vuepress-plugin-medium-zoom
- [ ] vuepress-plugin-named-chunks
- [ ] vuepress-plugin-nprogress
- [ ] vuepress-plugin-redirect
- [ ] vuepress-plugin-smooth-scroll
- [ ] vuepress-plugin-table-of-contents
- [ ] vuepress-plugin-typescript
- [ ] vuepress-plugin-zooming
- [ ] vuepress-mergeable
- [ ] vuepress-types

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fix)
- [ ] Feature (feat)
- [ ] Performance enhancement (perf)
- [ ] Code Style (style)
- [ ] Refactor (refactor)
- [ ] Docs (docs)
- [ ] Build-related changes (build)
- [ ] CI-related changes (ci)
- [ ] Testing (test)
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**

`String.prototype.find` will treat the first argument as regexp.

The vairable `resourceOriginal`, which contents is `{{{ renderResourceHints() }}}`, was not works as expected because `()` was treated as regex match groups. This leads to many unused tags generated in the ssr template.

indexOf is safe for any string to find the neddle in string.