### PR TITLE
fix(plugin-smooth-scroll): element can`t found when hash value is Chinese

### DIFF
--- a/packages/vuepress-plugin-smooth-scroll/src/enhanceApp.ts
+++ b/packages/vuepress-plugin-smooth-scroll/src/enhanceApp.ts
@@ -34,7 +34,7 @@ const enhanceApp: EnhanceApp = ({ Vue, router }): void => {
         return
       }
 
-      const targetAnchor = to.hash.slice(1)
+      const targetAnchor = decodeURIComponent(to.hash.slice(1))
       const targetElement =
         document.getElementById(targetAnchor) ||
         document.querySelector(`[name='${targetAnchor}']`)


### PR DESCRIPTION
…nese

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
element can`t found when hash value is Chinese
**Which package does this PR involve?** (check one)

- [ ] root project
- [ ] vuepress-plugin-clean-urls
- [ ] vuepress-plugin-container
- [ ] vuepress-plugin-dehydrate
- [ ] vuepress-plugin-medium-zoom
- [ ] vuepress-plugin-named-chunks
- [ ] vuepress-plugin-nprogress
- [ ] vuepress-plugin-redirect
- [x] vuepress-plugin-smooth-scroll
- [ ] vuepress-plugin-table-of-contents
- [ ] vuepress-plugin-typescript
- [ ] vuepress-plugin-zooming
- [ ] vuepress-mergeable
- [ ] vuepress-types

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fix)
- [ ] Feature (feat)
- [ ] Performance enhancement (perf)
- [ ] Code Style (style)
- [ ] Refactor (refactor)
- [ ] Docs (docs)
- [ ] Build-related changes (build)
- [ ] CI-related changes (ci)
- [ ] Testing (test)
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
