### PR TITLE
fix: default branch is main, not master

### DIFF
--- a/packages/docs/src/.vuepress/config.js
+++ b/packages/docs/src/.vuepress/config.js
@@ -103,6 +103,7 @@ module.exports = (context) => ({
 
   themeConfig: {
     repo: 'vuepress/vuepress-community',
+    docsBranch: 'main',
     editLinks: true,
     docsDir: 'packages/docs/src',
     locales: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When  click "[Edit this page on GitHub](https://github.com/vuepress/vuepress-community/edit/master/packages/docs/src/en/plugins/container.md)", get a 404 page, because the default branch is main, not master. So I modified it.


**Which package does this PR involve?** (check one)

- [x] root project
- [ ] vuepress-plugin-clean-urls
- [ ] vuepress-plugin-container
- [ ] vuepress-plugin-dehydrate
- [ ] vuepress-plugin-medium-zoom
- [ ] vuepress-plugin-named-chunks
- [ ] vuepress-plugin-nprogress
- [ ] vuepress-plugin-redirect
- [ ] vuepress-plugin-smooth-scroll
- [ ] vuepress-plugin-table-of-contents
- [ ] vuepress-plugin-typescript
- [ ] vuepress-plugin-zooming
- [ ] vuepress-mergeable
- [ ] vuepress-types

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (fix)
- [ ] Feature (feat)
- [ ] Performance enhancement (perf)
- [ ] Code Style (style)
- [ ] Refactor (refactor)
- [ ] Docs (docs)
- [ ] Build-related changes (build)
- [ ] CI-related changes (ci)
- [ ] Testing (test)
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
